### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@v1
-        id: generate-token
+        id: generate_token
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
generate-token -> generate_token

small typo probably keeping this action from pushing code..
<pre>
      - name: Create and push tag
        if: steps.check_tag.outputs.exists == 'false'
        working-directory: head
        env:
          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
        run: |
          git config --global url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
          git tag -f v${{ steps.versions.outputs.current_version }}
          git push --force origin v${{ steps.versions.outputs.current_version }}
      - name: Release
        if: steps.check_tag.outputs.exists == 'false'
        uses: softprops/action-gh-release@v2
        with:
          body_path: ${{ github.workspace }}/head/openapi-diff.md
          tag_name: v${{ steps.versions.outputs.current_version }}
          token: ${{ steps.generate_token.outputs.token }}
</pre>